### PR TITLE
Remove lighthouse from CI

### DIFF
--- a/.github/workflows/pull_request_audit.yml
+++ b/.github/workflows/pull_request_audit.yml
@@ -3,61 +3,6 @@ on:
   pull_request:
     branches: [main]
 jobs:
-  lighthouse:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./frontend
-    steps:
-      - uses: actions/checkout@v6
-      - name: Vercel Action
-        id: vercel_action
-        uses: amondnet/vercel-action@v25
-        with:
-          vercel-token: ${{ secrets.LONDON_VERCEL_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          vercel-org-id: ${{ secrets.ORG_ID }}
-          vercel-project-id: ${{ secrets.LONDON_PROJECT_ID }}
-      - name: Audit URLs using Lighthouse
-        id: lighthouse_audit
-        uses: treosh/lighthouse-ci-action@v12
-        with:
-          urls: |
-            ${{ steps.vercel_action.outputs.preview-url }}
-          budgetPath: ".github/lighthouse/budget.json"
-          uploadArtifacts: true
-          runs: 5
-      - name: Format lighthouse score
-        id: format_lighthouse_score
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const result = ${{ steps.lighthouse_audit.outputs.manifest }}[0].summary
-            const formatResult = (res) => Math.round((res * 100))
-            Object.keys(result).forEach(key => result[key] = formatResult(result[key]))
-            const score = res => res >= 90 ? '🟢' : res >= 50 ? '🟠' : '🔴'
-            const comment = [
-                `⚡️ [Lighthouse report] for the changes in this PR:`,
-                '| Category | Score |',
-                '| --- | --- |',
-                `| ${score(result.performance)} Performance | ${result.performance} |`,
-                `| ${score(result.accessibility)} Accessibility | ${result.accessibility} |`,
-                `| ${score(result['best-practices'])} Best practices | ${result['best-practices']} |`,
-                `| ${score(result.seo)} SEO | ${result.seo} |`,
-                `| ${score(result.pwa)} PWA | ${result.pwa} |`,
-                ' ',
-            ].join('\n')
-             core.setOutput("comment", comment);
-      - name: Add comment to PR
-        id: comment_to_pr
-        uses: marocchino/sticky-pull-request-comment@v3
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.issue.number }}
-          header: lighthouse
-          message: |
-            ${{ steps.format_lighthouse_score.outputs.comment }}
   axe:
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
## Summary
- Removes the `lighthouse` job from the CI workflow

## Test plan
- [ ] Verify the remaining `axe` job still runs correctly on PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)