### PR TITLE
perf: replace client-side fetch with getServerSideProps on public list pages

### DIFF
--- a/frontend/pages/list/[username].tsx
+++ b/frontend/pages/list/[username].tsx
@@ -1,7 +1,8 @@
 import Head from 'next/head';
-import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { GetServerSideProps } from 'next';
 import styles from './[username].module.css';
+
+const API_URL = process.env.STRAPI_URL || 'http://127.0.0.1:1337';
 
 type ListItem = {
   documentId: string;
@@ -16,51 +17,15 @@ type PublicListData = {
   username: string;
 };
 
-type PageState = 'loading' | 'found' | 'private' | 'not_found';
+type PageState = 'found' | 'private' | 'not_found';
 
-export default function PublicListPage() {
-  const router = useRouter();
-  const { username } = router.query;
-  const [listData, setListData] = useState<PublicListData | null>(null);
-  const [pageState, setPageState] = useState<PageState>('loading');
+type Props = {
+  pageState: PageState;
+  listData: PublicListData | null;
+  username: string;
+};
 
-  const API_URL = process.env.STRAPI_URL || 'http://127.0.0.1:1337';
-
-  useEffect(() => {
-    if (!username || typeof username !== 'string') return;
-
-    setPageState('loading');
-
-    const fetchPublicList = async () => {
-      try {
-        const res = await fetch(`${API_URL}/api/list-settings/public/${username}`);
-        if (res.status === 403) {
-          setPageState('private');
-        } else if (res.status === 404) {
-          setPageState('not_found');
-        } else if (res.ok) {
-          const data: PublicListData = await res.json();
-          setListData(data);
-          setPageState('found');
-        } else {
-          setPageState('not_found');
-        }
-      } catch {
-        setPageState('not_found');
-      }
-    };
-
-    fetchPublicList();
-  }, [username, API_URL]);
-
-  if (pageState === 'loading') {
-    return (
-      <main className={styles.main}>
-        <p>Loading...</p>
-      </main>
-    );
-  }
-
+export default function PublicListPage({ pageState, listData, username }: Props) {
   if (pageState === 'not_found') {
     return (
       <main className={styles.main}>
@@ -132,3 +97,24 @@ export default function PublicListPage() {
     </>
   );
 }
+
+export const getServerSideProps: GetServerSideProps<Props> = async (context) => {
+  const { username } = context.params as { username: string };
+
+  try {
+    const res = await fetch(`${API_URL}/api/list-settings/public/${username}`);
+    if (res.status === 403) {
+      return { props: { pageState: 'private', listData: null, username } };
+    }
+    if (res.status === 404) {
+      return { props: { pageState: 'not_found', listData: null, username } };
+    }
+    if (res.ok) {
+      const data: PublicListData = await res.json();
+      return { props: { pageState: 'found', listData: data, username } };
+    }
+    return { props: { pageState: 'not_found', listData: null, username } };
+  } catch {
+    return { props: { pageState: 'not_found', listData: null, username } };
+  }
+};

--- a/frontend/pages/list/[username]/[listId].tsx
+++ b/frontend/pages/list/[username]/[listId].tsx
@@ -1,6 +1,5 @@
 import Head from 'next/head';
-import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { GetServerSideProps } from 'next';
 import styles from '../[username].module.css';
 
 const API_URL = process.env.STRAPI_URL || 'http://127.0.0.1:1337';
@@ -19,49 +18,15 @@ type PublicListData = {
   listName: string;
 };
 
-type PageState = 'loading' | 'found' | 'private' | 'not_found';
+type PageState = 'found' | 'private' | 'not_found';
 
-export default function PublicListPage() {
-  const router = useRouter();
-  const { username, listId } = router.query;
-  const [listData, setListData] = useState<PublicListData | null>(null);
-  const [pageState, setPageState] = useState<PageState>('loading');
+type Props = {
+  pageState: PageState;
+  listData: PublicListData | null;
+  username: string;
+};
 
-  useEffect(() => {
-    if (!username || typeof username !== 'string' || !listId || typeof listId !== 'string') return;
-
-    setPageState('loading');
-
-    const fetchPublicList = async () => {
-      try {
-        const res = await fetch(`${API_URL}/api/lists/public/${username}/${listId}`);
-        if (res.status === 403) {
-          setPageState('private');
-        } else if (res.status === 404) {
-          setPageState('not_found');
-        } else if (res.ok) {
-          const data: PublicListData = await res.json();
-          setListData(data);
-          setPageState('found');
-        } else {
-          setPageState('not_found');
-        }
-      } catch {
-        setPageState('not_found');
-      }
-    };
-
-    fetchPublicList();
-  }, [username, listId]);
-
-  if (pageState === 'loading') {
-    return (
-      <main className={styles.main}>
-        <p>Loading...</p>
-      </main>
-    );
-  }
-
+export default function PublicListPage({ pageState, listData, username }: Props) {
   if (pageState === 'not_found') {
     return (
       <main className={styles.main}>
@@ -136,3 +101,24 @@ export default function PublicListPage() {
     </>
   );
 }
+
+export const getServerSideProps: GetServerSideProps<Props> = async (context) => {
+  const { username, listId } = context.params as { username: string; listId: string };
+
+  try {
+    const res = await fetch(`${API_URL}/api/lists/public/${username}/${listId}`);
+    if (res.status === 403) {
+      return { props: { pageState: 'private', listData: null, username } };
+    }
+    if (res.status === 404) {
+      return { props: { pageState: 'not_found', listData: null, username } };
+    }
+    if (res.ok) {
+      const data: PublicListData = await res.json();
+      return { props: { pageState: 'found', listData: data, username } };
+    }
+    return { props: { pageState: 'not_found', listData: null, username } };
+  } catch {
+    return { props: { pageState: 'not_found', listData: null, username } };
+  }
+};


### PR DESCRIPTION
## Summary

Both public list pages (`/list/[username]` and `/list/[username]/[listId]`) were fetching data in a `useEffect` after mount. This meant every visitor saw a loading spinner before content appeared, and search engines / social media scrapers received a blank page.

- Replaces the `useEffect` + state approach with `getServerSideProps` on both pages
- Component now receives `pageState`, `listData`, and `username` as props and renders fully on first paint
- Removes `useRouter`, `useEffect`, and `useState` from both components — they are no longer needed
- 403/404/error cases are all handled server-side and passed as `pageState` props

## Test plan

- [ ] Visit a public list URL — confirm content renders without a loading spinner
- [ ] Visit a private list URL — confirm the "This list is private" message renders immediately
- [ ] Visit a non-existent user/list URL — confirm the not-found message renders immediately
- [ ] Disable JS in the browser and confirm content still renders (validates SSR)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)